### PR TITLE
Fixes to use of long term statistics, so that addon can be used with …

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,6 +11,7 @@ from .const import (
     DOMAIN,
     CONF_IP_ADDRESS,
     CONF_INVERTER_SERIAL,
+    CONF_NAME_ID,
     CONF_PASSWORD,
     CONF_PORT
 )
@@ -48,6 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     inverter[CONF_IP_ADDRESS] = inverter_config[CONF_IP_ADDRESS]
     inverter[CONF_PORT] = inverter_config[CONF_PORT]
     inverter[CONF_INVERTER_SERIAL] = inverter_config[CONF_INVERTER_SERIAL]
+    inverter[CONF_NAME_ID] = inverter_config[CONF_NAME_ID]
     inverter[CONF_PASSWORD] = inverter_config[CONF_PASSWORD]
 
     on_connection_lost = hass.loop.create_future()

--- a/config_flow.py
+++ b/config_flow.py
@@ -11,6 +11,7 @@ from .const import (
     DOMAIN,
     CONF_IP_ADDRESS,
     CONF_INVERTER_SERIAL,
+    CONF_NAME_ID,
     CONF_PASSWORD,
     CONF_PORT
 )
@@ -37,6 +38,7 @@ class CANSwitchFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             self.ip_address = user_input[CONF_IP_ADDRESS]
             self.serial_number = user_input[CONF_INVERTER_SERIAL]
+            self.name_id = user_input[CONF_NAME_ID]
             self.password = user_input[CONF_PASSWORD]
             self.port = user_input[CONF_PORT]
 
@@ -44,6 +46,7 @@ class CANSwitchFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 title=self.ip_address, data={
                     CONF_IP_ADDRESS: self.ip_address,
                     CONF_INVERTER_SERIAL: self.serial_number,
+                    CONF_NAME_ID: self.name_id,
                     CONF_PASSWORD: self.password,
                     CONF_PORT: self.port
                 }
@@ -55,7 +58,8 @@ class CANSwitchFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_IP_ADDRESS): cv.string,
                     vol.Required(CONF_INVERTER_SERIAL): cv.positive_int,
-                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Required(CONF_NAME_ID, default="sma"): cv.string,
+                    vol.Required(CONF_PASSWORD, default="0000"): cv.string,
                     vol.Optional(CONF_PORT, default=9522): cv.positive_int
                 }
             ),

--- a/const.py
+++ b/const.py
@@ -7,6 +7,7 @@ DEFAULT_NAME = "SunnyBoy Inverter Speedwire"
 
 CONF_IP_ADDRESS = "ip_address"
 CONF_INVERTER_SERIAL = "serial"
+CONF_NAME_ID = "name_id"
 CONF_PORT = "port"
 CONF_PASSWORD = "user_password"
 CONF_QUERY_LIST = "command_query_list"

--- a/strings.json
+++ b/strings.json
@@ -12,6 +12,7 @@
         "data": {
           "ip_address": "IP Address",
           "serial": "Inverter Serial Number",
+          "name_id": "Name ID",
           "port": "Speedwire Port",
           "user_password": "user password"
         }

--- a/translations/en.json
+++ b/translations/en.json
@@ -12,6 +12,7 @@
         "data": {
           "ip_address": "IP Address",
           "serial": "Inverter Serial Number",
+          "ID Name": "ID Name",
           "port": "Speedwire Port",
           "user_password": "user password"
         }


### PR DESCRIPTION
Thanks for the addon. Very useful.

My fixes are for the usage of long term statistics, so that addon can be used with the standard Energy Dashboard.
I also introduce Name configuration, for naming of created sensors.

I found that the home assistant Energy Dashboard did not recognise any data from the addon and so the sensors could not be used with the Energy Dashboard. 

regards
Charly